### PR TITLE
README addition: alternate go generate comment

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,3 +8,4 @@ Svetlin Ralchev - https://github.com/svett
 Steve Kemp - https://github.com/skx
 Ashish Acharya - https://github.com/anarchyrucks
 Tobi Fuhrimann - https://github.com/mastertinner
+Michael Christenson II - https://github.com/m3talsmith

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ package database
 //go:generate parcello -r
 ```
 
+Alternatively, if you don't wish to install the cli for any reason, you can use this `go generate` comment instead:
+
+```golang
+// Package database contains the database artefacts of GOM as embedded resource
+package database
+
+//go:generate go run github.com/phogolabs/parcello/cmd/parcello -r
+```
+
 When you run:
 
 ```console


### PR DESCRIPTION
### Description

There are multiple cases in build environments and deployments where it's not convenient or possible to install cli tool for `go generate` to use. The (optional) alternative line lays out how you can use the cli in your `go generate` comment, without it being installed first.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible) - Does not apply
- [x] All tests passing
- [x] Extended the README.md / documentation, if necessary
- [X] Added myself / the copyright holder to the CONTRIBUTORS file
